### PR TITLE
Feature: Limit maximum amount of groups

### DIFF
--- a/sitzverteilung-frontend/src/components/GroupDataTable.vue
+++ b/sitzverteilung-frontend/src/components/GroupDataTable.vue
@@ -137,7 +137,10 @@
         @addGroup="addNewGroup"
         ref="groupDataTableAddRowRef"
       />
-      <group-data-table-summary-row :groups="groups" :max-groups="maxGroups"/>
+      <group-data-table-summary-row
+        :groups="groups"
+        :max-groups="maxGroups"
+      />
     </template>
   </v-data-table>
 </template>
@@ -163,7 +166,7 @@ const headers = [
 ] as const;
 
 const props = defineProps<{
-  maxGroups: number
+  maxGroups: number;
 }>();
 
 const groups = defineModel<Group[]>({ required: true });
@@ -202,6 +205,7 @@ function deleteGroups() {
 
 function deleteGroup(index: number) {
   groups.value.splice(index, 1);
+  selected.value = [];
   validateNameFields();
 }
 </script>

--- a/sitzverteilung-frontend/src/components/GroupDataTable.vue
+++ b/sitzverteilung-frontend/src/components/GroupDataTable.vue
@@ -133,10 +133,11 @@
     <template #body.append>
       <group-data-table-add-row
         :group-names="groupNames"
+        :disabled="limitReached"
         @addGroup="addNewGroup"
         ref="groupDataTableAddRowRef"
       />
-      <group-data-table-summary-row :groups="groups" />
+      <group-data-table-summary-row :groups="groups" :max-groups="maxGroups"/>
     </template>
   </v-data-table>
 </template>
@@ -161,8 +162,13 @@ const headers = [
   { title: "Aktionen", key: "actions", align: "center", width: 100 },
 ] as const;
 
+const props = defineProps<{
+  maxGroups: number
+}>();
+
 const groups = defineModel<Group[]>({ required: true });
 const groupNames = computed(() => groups.value.map((group) => group.name));
+const limitReached = computed(() => groups.value.length >= props.maxGroups);
 
 function addNewGroup(group: Group) {
   groups.value.push(group);

--- a/sitzverteilung-frontend/src/components/GroupDataTableAddRow.vue
+++ b/sitzverteilung-frontend/src/components/GroupDataTableAddRow.vue
@@ -20,6 +20,7 @@
         density="compact"
         class="py-3"
         @keydown.enter="addGroupEnter"
+        :disabled="disabled"
       />
     </td>
     <td>
@@ -43,6 +44,7 @@
         density="compact"
         class="py-3"
         @keydown.enter="addGroupEnter"
+        :disabled="disabled"
       />
     </td>
     <td>
@@ -66,13 +68,14 @@
         density="compact"
         class="py-3"
         @keydown.enter="addGroupEnter"
+        :disabled="disabled"
       />
     </td>
     <td>
       <div class="d-flex justify-center">
         <v-btn
           @click="addGroup"
-          :disabled="isEmpty || !isValid"
+          :disabled="disabled || isEmpty || !isValid"
           :icon="mdiPlus"
           size="small"
           color="primary"
@@ -96,6 +99,7 @@ import { FieldValidationRules } from "@/utility/rules";
 
 defineProps<{
   groupNames: string[];
+  disabled: boolean
 }>();
 
 const newGroup = ref<Group>(getEmptyGroup());

--- a/sitzverteilung-frontend/src/components/GroupDataTableAddRow.vue
+++ b/sitzverteilung-frontend/src/components/GroupDataTableAddRow.vue
@@ -97,7 +97,7 @@ import { computed, ref, useTemplateRef, watch } from "vue";
 import { checkNumberInput } from "@/utility/input";
 import { FieldValidationRules } from "@/utility/rules";
 
-defineProps<{
+const props = defineProps<{
   groupNames: string[];
   disabled: boolean
 }>();
@@ -154,6 +154,14 @@ function resetValidation() {
   committeeSeatsInputField.value?.resetValidation();
   votesInputField.value?.resetValidation();
 }
+
+watch(() => props.disabled, (isDisabled) => {
+  if (isDisabled) {
+    newGroup.value = getEmptyGroup();
+    resetValidation();
+  }
+});
+
 defineExpose({
   validateNameField,
 });

--- a/sitzverteilung-frontend/src/components/GroupDataTableAddRow.vue
+++ b/sitzverteilung-frontend/src/components/GroupDataTableAddRow.vue
@@ -99,7 +99,7 @@ import { FieldValidationRules } from "@/utility/rules";
 
 const props = defineProps<{
   groupNames: string[];
-  disabled: boolean
+  disabled: boolean;
 }>();
 
 const newGroup = ref<Group>(getEmptyGroup());
@@ -155,12 +155,15 @@ function resetValidation() {
   votesInputField.value?.resetValidation();
 }
 
-watch(() => props.disabled, (isDisabled) => {
-  if (isDisabled) {
-    newGroup.value = getEmptyGroup();
-    resetValidation();
+watch(
+  () => props.disabled,
+  (isDisabled) => {
+    if (isDisabled) {
+      newGroup.value = getEmptyGroup();
+      resetValidation();
+    }
   }
-});
+);
 
 defineExpose({
   validateNameField,

--- a/sitzverteilung-frontend/src/components/GroupDataTableSummaryRow.vue
+++ b/sitzverteilung-frontend/src/components/GroupDataTableSummaryRow.vue
@@ -2,7 +2,12 @@
   <tr class="bg-primary">
     <td />
     <td>
-      <p class="font-weight-bold">Gesamtanzahl: {{ amountOfGroups }}<span :class="{ 'text-red': tooManyGroups }"> (max. {{ maxGroups }})</span></p>
+      <p class="font-weight-bold">
+        Gesamtanzahl: {{ amountOfGroups
+        }}<span :class="{ 'text-red': tooManyGroups }">
+          (max. {{ maxGroups }})</span
+        >
+      </p>
     </td>
     <td>
       <p class="font-weight-bold">Gesamtanzahl: {{ groupSeatsSum }}</p>

--- a/sitzverteilung-frontend/src/components/GroupDataTableSummaryRow.vue
+++ b/sitzverteilung-frontend/src/components/GroupDataTableSummaryRow.vue
@@ -2,7 +2,7 @@
   <tr class="bg-primary">
     <td />
     <td>
-      <p class="font-weight-bold">Gesamtanzahl: {{ groupSize }}</p>
+      <p class="font-weight-bold">Gesamtanzahl: {{ amountOfGroups }}<span :class="{ 'text-red': tooManyGroups }"> (max. {{ maxGroups }})</span></p>
     </td>
     <td>
       <p class="font-weight-bold">Gesamtanzahl: {{ groupSeatsSum }}</p>
@@ -19,9 +19,12 @@ import { computed } from "vue";
 
 const props = defineProps<{
   groups: Group[];
+  maxGroups: number;
 }>();
 
-const groupSize = computed(() => props.groups.length);
+const amountOfGroups = computed(() => props.groups.length);
+const tooManyGroups = computed(() => amountOfGroups.value > props.maxGroups);
+
 const groupSeatsSum = computed(() => {
   return props.groups.reduce(
     (sum, group) => sum + (group.committeeSeats ?? 0),

--- a/sitzverteilung-frontend/src/views/DataView.vue
+++ b/sitzverteilung-frontend/src/views/DataView.vue
@@ -7,7 +7,7 @@
     </v-row>
     <v-row>
       <v-col cols="9">
-        <group-data-table v-model="groups" />
+        <group-data-table v-model="groups" :max-groups="3"/>
       </v-col>
     </v-row>
   </v-container>

--- a/sitzverteilung-frontend/src/views/DataView.vue
+++ b/sitzverteilung-frontend/src/views/DataView.vue
@@ -7,7 +7,10 @@
     </v-row>
     <v-row>
       <v-col cols="9">
-        <group-data-table v-model="groups" :max-groups="80"/>
+        <group-data-table
+          v-model="groups"
+          :max-groups="80"
+        />
       </v-col>
     </v-row>
   </v-container>

--- a/sitzverteilung-frontend/src/views/DataView.vue
+++ b/sitzverteilung-frontend/src/views/DataView.vue
@@ -7,7 +7,7 @@
     </v-row>
     <v-row>
       <v-col cols="9">
-        <group-data-table v-model="groups" :max-groups="3"/>
+        <group-data-table v-model="groups" :max-groups="80"/>
       </v-col>
     </v-row>
   </v-container>


### PR DESCRIPTION
# Pull Request

## Changes

- Added feature to limit rowsize of basedata by setting `max-groups` property
- Max row size will be 80 for now but later be influenced by the given total size

## Reference

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [x] Wrote code and comments in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a maximum group limit, preventing users from adding more than 80 groups.
	- The interface now displays the current and maximum number of groups, with a visual indicator if the limit is exceeded.
	- The add group form is automatically disabled and cleared when the group limit is reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->