### PR TITLE
:recycle: Keep base data after edits saved

### DIFF
--- a/sitzverteilung-frontend/src/components/basedata/BaseDataAutocomplete.vue
+++ b/sitzverteilung-frontend/src/components/basedata/BaseDataAutocomplete.vue
@@ -1,6 +1,7 @@
 <template>
   <v-autocomplete
     ref="autocompleteRef"
+    :model-value="selectedBaseData"
     :items="baseDataList"
     item-title="name"
     item-value="name"
@@ -65,9 +66,7 @@ import {
 } from "@mdi/js";
 import { computed, ref, useTemplateRef } from "vue";
 
-const emit = defineEmits<{
-  update: [baseData: BaseData];
-}>();
+const selectedBaseData = defineModel<BaseData>();
 
 const autocompleteRef = useTemplateRef<VAutocomplete>("autocompleteRef");
 
@@ -80,15 +79,16 @@ const searchText = ref("");
 function updateSearchText(newSearchText: string) {
   searchText.value = newSearchText;
   if (!newSearchText?.trim()) {
-    itemSelected.value = false;
+    isItemSelected.value = false;
   }
 }
 
-const itemSelected = ref(false);
+const isItemSelected = ref(false);
 function updateSelection(selectedItem: BaseData | null) {
   if (selectedItem) {
-    itemSelected.value = true;
-    emit("update", selectedItem);
+    isItemSelected.value = true;
+    selectedBaseData.value = selectedItem;
+    unfocus();
   }
 }
 
@@ -102,33 +102,34 @@ const isAlreadyExistent = computed(() =>
 
 function clickClear() {
   createNewEmptyBaseData();
-  itemSelected.value = false;
+  isItemSelected.value = false;
 }
 
 function createNewBaseDataByName() {
-  emit("update", {
+  selectedBaseData.value = {
     name: searchText.value.trim(),
     committeeSize: undefined,
     unions: [],
     groups: [],
-  });
+  };
   reset();
   unfocus();
 }
 
 function hitEnter() {
-  if (!itemSelected.value) {
+  if (!isItemSelected.value) {
     createNewBaseDataByName();
   }
 }
 
 function createNewEmptyBaseData() {
-  emit("update", {
+  selectedBaseData.value = {
     name: "",
     committeeSize: undefined,
     unions: [],
     groups: [],
-  });
+  };
+  unfocus();
 }
 
 function reset() {


### PR DESCRIPTION
# Pull Request

## Changes

- Keep Base Data in form after edits where saved

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved state management for base data selection by switching from event-based updates to direct model binding.
  * Enhanced clarity by renaming selection state variables.
  * Simplified and unified control flow for selecting, clearing, and saving base data.

* **Style**
  * The delete confirmation dialog now dynamically displays the name of the selected base data for better user feedback.

* **Bug Fixes**
  * The autocomplete input is now automatically blurred after selection or clearing actions for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->