### PR TITLE
:bug: Fix console errors by removing number modifier on number inputs

### DIFF
--- a/sitzverteilung-frontend/src/components/basedata/BaseDataForm.vue
+++ b/sitzverteilung-frontend/src/components/basedata/BaseDataForm.vue
@@ -21,7 +21,7 @@
       </v-col>
       <v-col>
         <v-number-input
-          v-model.number="baseData.committeeSize"
+          v-model="baseData.committeeSize"
           :rules="[FieldValidationRules.Required]"
           :min="1"
           :max="limitCommitteeSize"

--- a/sitzverteilung-frontend/src/components/basedata/groupdata/GroupDataTableRow.vue
+++ b/sitzverteilung-frontend/src/components/basedata/groupdata/GroupDataTableRow.vue
@@ -28,7 +28,7 @@
     </td>
     <td>
       <v-number-input
-        v-model.number="group.committeeSeats"
+        v-model="group.committeeSeats"
         ref="committeeSeatsInputField"
         :rules="applyRules ? [FieldValidationRules.Required] : []"
         :min="1"
@@ -44,7 +44,7 @@
     </td>
     <td>
       <v-number-input
-        v-model.number="group.votes"
+        v-model="group.votes"
         ref="votesInputField"
         :min="1"
         :max="limitVotes"


### PR DESCRIPTION
# Pull Request

## Changes

- Fixed console errors when number field input was changed

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated input fields to remove automatic numeric casting when entering committee size, committee seats, and votes. Input values are now bound directly without automatic conversion. No other functionality or validation is affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->