### PR TITLE
:bug: Fix name duplication on edit

### DIFF
--- a/sitzverteilung-frontend/src/components/basedata/BaseDataForm.vue
+++ b/sitzverteilung-frontend/src/components/basedata/BaseDataForm.vue
@@ -113,7 +113,7 @@ const committees = computed({
 
 const {
   baseDataNames = [],
-  isEditing,
+  selectedBaseDataName,
   limitName,
   limitGroups,
   limitVotes,
@@ -123,7 +123,7 @@ const {
   limitGroups: number;
   limitVotes: number;
   limitCommitteeSize: number;
-  isEditing: boolean;
+  selectedBaseDataName?: string;
   baseDataNames?: string[];
 }>();
 
@@ -144,9 +144,15 @@ const seatFieldValidationError = computed(() => {
   return "";
 });
 
-const comparedBaseDataNames = computed(() =>
-  isEditing ? baseDataNames : [...baseDataNames, baseData.value.name]
-);
+const comparedBaseDataNames = computed(() => {
+  let relevantBaseDataNames = baseDataNames;
+  if (selectedBaseDataName !== undefined && selectedBaseDataName !== null) {
+    relevantBaseDataNames = relevantBaseDataNames.filter(
+      (name) => name !== selectedBaseDataName
+    );
+  }
+  return [...relevantBaseDataNames, baseData.value.name];
+});
 
 const expectedSeats = computed(() => baseData.value.committeeSize ?? 0);
 const limitGroupsRef = toRef(() => limitGroups);

--- a/sitzverteilung-frontend/src/views/DataView.vue
+++ b/sitzverteilung-frontend/src/views/DataView.vue
@@ -187,7 +187,7 @@
           :limit-groups="LimitConfiguration.limitGroups"
           :limit-committee-size="LimitConfiguration.limitCommitteeSize"
           :limit-votes="LimitConfiguration.limitVotes"
-          :is-editing="isBaseDataSelected"
+          :selected-base-data-name="selectedBaseData?.name"
           :base-data-names="baseDataNames"
         />
       </v-col>


### PR DESCRIPTION
# Pull Request

## Changes

- Fixed bug when editing existing item names of already saved data is not respected on validation

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the selection logic in forms to use the name of the selected base data instead of a simple editing flag, improving clarity and consistency in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->