### PR TITLE
:recycle: Removed create shortcut functionality from autocomplete

### DIFF
--- a/sitzverteilung-frontend/src/components/basedata/BaseDataAutocomplete.vue
+++ b/sitzverteilung-frontend/src/components/basedata/BaseDataAutocomplete.vue
@@ -1,7 +1,6 @@
 <template>
   <v-autocomplete
-    ref="autocompleteRef"
-    :model-value="selectedBaseData"
+    v-model="selectedBaseData"
     :items="baseDataList"
     item-title="name"
     item-value="name"
@@ -9,10 +8,6 @@
     persistent-clear
     clearable
     auto-select-first
-    @update:search="updateSearchText"
-    @update:model-value="updateSelection"
-    @keydown.enter="hitEnter"
-    @click:clear.stop="clickClear"
     :maxlength="limitName"
     label="Basisdaten wählen (optional)"
     hide-details
@@ -22,33 +17,23 @@
     variant="outlined"
     density="comfortable"
     autocomplete="off"
+    no-data-text="Keine passenden Basisdaten gefunden"
   >
     <template #item="{ props }">
       <v-list-item v-bind="props">
         <template #prepend>
-          <v-icon :icon="mdiFileDocumentEdit" />
+          <v-icon :icon="mdiFileDocumentMultiple" />
         </template>
-      </v-list-item>
-    </template>
-    <template
-      #append-item
-      v-if="searchText && !isAlreadyExistent"
-    >
-      <v-list-item @click="createNewBaseDataByName">
-        <template #prepend>
-          <v-icon :icon="mdiFileDocumentPlus" />
-        </template>
-        <v-list-item-title>
-          Basisdaten '{{ searchText }}' anlegen
-        </v-list-item-title>
       </v-list-item>
     </template>
     <template #no-data>
-      <v-list-item v-if="isBaseDataListEmpty && !searchText">
+      <v-list-item>
         <template #prepend>
           <v-icon :icon="mdiInformation" />
         </template>
-        <v-list-item-title> Name eingeben zum Anlegen </v-list-item-title>
+        <v-list-item-title
+          >Keine passenden Basisdaten gefunden.</v-list-item-title
+        >
       </v-list-item>
     </template>
   </v-autocomplete>
@@ -58,89 +43,12 @@
 import type { BaseData } from "@/types/BaseData.ts";
 import type { VAutocomplete } from "vuetify/components";
 
-import {
-  mdiFileDocumentEdit,
-  mdiFileDocumentMultiple,
-  mdiFileDocumentPlus,
-  mdiInformation,
-} from "@mdi/js";
-import { computed, ref, useTemplateRef } from "vue";
+import { mdiFileDocumentMultiple, mdiInformation } from "@mdi/js";
 
-const selectedBaseData = defineModel<BaseData>();
+const selectedBaseData = defineModel<BaseData | null>();
 
-const autocompleteRef = useTemplateRef<VAutocomplete>("autocompleteRef");
-
-const props = defineProps<{
+defineProps<{
   baseDataList: BaseData[];
   limitName: number;
 }>();
-
-const searchText = ref("");
-function updateSearchText(newSearchText: string) {
-  searchText.value = newSearchText;
-  if (!newSearchText?.trim()) {
-    isItemSelected.value = false;
-  }
-}
-
-const isItemSelected = ref(false);
-function updateSelection(selectedItem: BaseData | null) {
-  if (selectedItem) {
-    isItemSelected.value = true;
-    selectedBaseData.value = selectedItem;
-    unfocus();
-  }
-}
-
-const isBaseDataListEmpty = computed(() => props.baseDataList.length === 0);
-const baseDataNames = computed(() =>
-  props.baseDataList.map((baseData) => baseData.name)
-);
-const isAlreadyExistent = computed(() =>
-  baseDataNames.value.includes(searchText.value.trim())
-);
-
-function clickClear() {
-  createNewEmptyBaseData();
-  isItemSelected.value = false;
-}
-
-function createNewBaseDataByName() {
-  selectedBaseData.value = {
-    name: searchText.value.trim(),
-    committeeSize: undefined,
-    unions: [],
-    groups: [],
-  };
-  reset();
-  unfocus();
-}
-
-function hitEnter() {
-  if (!isItemSelected.value) {
-    createNewBaseDataByName();
-  }
-}
-
-function createNewEmptyBaseData() {
-  selectedBaseData.value = {
-    name: "",
-    committeeSize: undefined,
-    unions: [],
-    groups: [],
-  };
-  unfocus();
-}
-
-function reset() {
-  autocompleteRef.value?.reset();
-}
-
-function unfocus() {
-  autocompleteRef.value?.blur();
-}
-
-defineExpose({
-  reset,
-});
 </script>

--- a/sitzverteilung-frontend/src/components/basedata/BaseDataForm.vue
+++ b/sitzverteilung-frontend/src/components/basedata/BaseDataForm.vue
@@ -123,7 +123,7 @@ const {
   limitGroups: number;
   limitVotes: number;
   limitCommitteeSize: number;
-  selectedBaseDataName?: string;
+  selectedBaseDataName?: string | null;
   baseDataNames?: string[];
 }>();
 
@@ -146,7 +146,7 @@ const seatFieldValidationError = computed(() => {
 
 const comparedBaseDataNames = computed(() => {
   let relevantBaseDataNames = baseDataNames;
-  if (selectedBaseDataName !== undefined && selectedBaseDataName !== null) {
+  if (selectedBaseDataName !== null) {
     relevantBaseDataNames = relevantBaseDataNames.filter(
       (name) => name !== selectedBaseDataName
     );

--- a/sitzverteilung-frontend/src/components/basedata/BaseDataForm.vue
+++ b/sitzverteilung-frontend/src/components/basedata/BaseDataForm.vue
@@ -146,7 +146,7 @@ const seatFieldValidationError = computed(() => {
 
 const comparedBaseDataNames = computed(() => {
   let relevantBaseDataNames = baseDataNames;
-  if (selectedBaseDataName !== null) {
+  if (selectedBaseDataName) {
     relevantBaseDataNames = relevantBaseDataNames.filter(
       (name) => name !== selectedBaseDataName
     );

--- a/sitzverteilung-frontend/src/composables/useSaveLeave.ts
+++ b/sitzverteilung-frontend/src/composables/useSaveLeave.ts
@@ -32,13 +32,13 @@ export function useSaveLeave(isDirty: Ref<boolean>) {
 
   function cancel(): void {
     saveLeaveDialog.value = false;
-    if (nextRoute.value != null) {
+    if (nextRoute.value) {
       nextRoute.value(false);
     }
   }
 
   function leave(): void {
-    if (nextRoute.value != null) {
+    if (nextRoute.value) {
       nextRoute.value();
     }
   }

--- a/sitzverteilung-frontend/src/views/DataView.vue
+++ b/sitzverteilung-frontend/src/views/DataView.vue
@@ -298,13 +298,10 @@ function deleteSelectedBaseData() {
 }
 
 watch(selectedBaseData, (newBaseData) => {
-  if (newBaseData === null || newBaseData === undefined) {
+  if (!newBaseData) {
     reset();
-    return;
-  }
-  currentBaseData.value = JSON.parse(JSON.stringify(newBaseData));
-  if (currentBaseData.value.committeeSize == null) {
-    isValid.value = false;
+  } else {
+    currentBaseData.value = JSON.parse(JSON.stringify(newBaseData));
   }
 });
 
@@ -355,7 +352,7 @@ watch(
   () => route.query.import,
   async (newImport) => {
     const importParam = newImport?.toString() ?? "";
-    if (importParam !== "") {
+    if (importParam) {
       try {
         const baseData = await writeUrlParamToObject<BaseData>(importParam);
         if (!isValidBaseData(baseData)) {

--- a/sitzverteilung-frontend/src/views/DataView.vue
+++ b/sitzverteilung-frontend/src/views/DataView.vue
@@ -137,7 +137,6 @@
       <v-row>
         <v-col class="d-flex align-center">
           <base-data-autocomplete
-            ref="baseDataAutocompleteRef"
             v-model="selectedBaseData"
             :limit-name="LimitConfiguration.limitName"
             :base-data-list="storedBaseData"
@@ -222,13 +221,8 @@ const snackbar = useSnackbarStore();
 
 const storedBaseData = computed(() => store.baseDatas);
 
-const selectedBaseData = ref<BaseData>();
-const isBaseDataSelected = computed(
-  () =>
-    !!selectedBaseData.value &&
-    selectedBaseData.value.name !== "" &&
-    baseDataNames.value.includes(selectedBaseData.value.name)
-);
+const selectedBaseData = ref<BaseData | null>();
+const isBaseDataSelected = computed(() => !!selectedBaseData.value);
 
 const dirty = computed(
   () =>
@@ -299,15 +293,12 @@ function deleteSelectedBaseData() {
     snackbar.showMessage({
       message: `Die Basisdaten '${selectedBaseData.value.name}' wurden gelöscht.`,
     });
-    selectedBaseData.value = undefined;
+    selectedBaseData.value = null;
   }
 }
 
-const baseDataAutocompleteRef = useTemplateRef<typeof BaseDataAutocomplete>(
-  "baseDataAutocompleteRef"
-);
 watch(selectedBaseData, (newBaseData) => {
-  if (newBaseData === undefined || newBaseData.name === "") {
+  if (newBaseData === null || newBaseData === undefined) {
     reset();
     return;
   }
@@ -318,12 +309,12 @@ watch(selectedBaseData, (newBaseData) => {
 });
 
 function reset() {
-  baseDataAutocompleteRef.value?.reset();
   baseDataFormRef.value?.reset();
   currentBaseData.value = getEmptyBaseData();
 }
 
 const { copy, isSupported } = useClipboard();
+
 async function share() {
   if (isBaseDataSelected.value && selectedBaseData.value) {
     if (!isSupported.value) {
@@ -378,7 +369,7 @@ watch(
             currentBaseData.value = baseData;
           });
           snackbar.showMessage({
-            message: `Die Basisdaten '${baseData.name}' wurden importiert. ACHTUNG: Erst beim Speichern werden diese permanent gespeichert.`,
+            message: `Die Basisdaten '${baseData.name}' wurden übertragen. ACHTUNG: Erst beim Speichern werden diese permanent gespeichert.`,
           });
         }
       } catch {


### PR DESCRIPTION
# Pull Request

## Changes

- Removed comfort functionality to transfer autocomplete input to name field for creating new data
-> Autocomplete now only allows selection of already saved data


## Checklist

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the base data selection component to only allow choosing from existing entries, removing support for creating new entries and related interactions.
  * Adjusted selection logic across components to consistently use null instead of undefined for unselected states.
  * Updated user feedback message from "importiert" to "übertragen" after data transfer.
  * Streamlined conditional checks related to base data selection and route navigation.

* **Style**
  * Changed the icon for base data list items for improved clarity.

* **Bug Fixes**
  * Improved type handling for base data selection to prevent potential issues with undefined values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->