### PR TITLE
fixed button now disabled when name is not changed

### DIFF
--- a/sitzverteilung-frontend/src/views/DataView.vue
+++ b/sitzverteilung-frontend/src/views/DataView.vue
@@ -147,7 +147,11 @@
             size="large"
             class="ml-5"
             :prepend-icon="mdiContentSave"
-            :disabled="!isValid || (isBaseDataSelected && !dirty) || basedataNameIsNotChanged"
+            :disabled="
+              !isValid ||
+              (isBaseDataSelected && !dirty) ||
+              basedataNameIsNotChanged
+            "
             @click="createBaseData"
             >Anlegen
           </v-btn>

--- a/sitzverteilung-frontend/src/views/DataView.vue
+++ b/sitzverteilung-frontend/src/views/DataView.vue
@@ -147,7 +147,7 @@
             size="large"
             class="ml-5"
             :prepend-icon="mdiContentSave"
-            :disabled="!isValid || (isBaseDataSelected && !dirty)"
+            :disabled="!isValid || (isBaseDataSelected && !dirty) || basedataNameIsNotChanged"
             @click="createBaseData"
             >Anlegen
           </v-btn>
@@ -254,6 +254,13 @@ const isDataEntered = computed(
       JSON.stringify(currentBaseData.value) !==
         JSON.stringify(getEmptyBaseData()))
 );
+
+const basedataNameIsNotChanged = computed(() => {
+  if (currentBaseData.value && selectedBaseData.value) {
+    return currentBaseData.value.name === selectedBaseData.value.name;
+  }
+  return false;
+});
 const saveLeave = useSaveLeave(isDataEntered);
 
 const baseDataNames = computed(() =>

--- a/sitzverteilung-frontend/src/views/DataView.vue
+++ b/sitzverteilung-frontend/src/views/DataView.vue
@@ -259,12 +259,10 @@ const isDataEntered = computed(
         JSON.stringify(getEmptyBaseData()))
 );
 
-const basedataNameIsNotChanged = computed(() => {
-  if (currentBaseData.value && selectedBaseData.value) {
-    return currentBaseData.value.name === selectedBaseData.value.name;
-  }
-  return false;
-});
+const basedataNameIsNotChanged = computed(
+  () => currentBaseData.value?.name === selectedBaseData.value?.name
+);
+
 const saveLeave = useSaveLeave(isDataEntered);
 
 const baseDataNames = computed(() =>

--- a/sitzverteilung-frontend/src/views/DataView.vue
+++ b/sitzverteilung-frontend/src/views/DataView.vue
@@ -259,7 +259,9 @@ const isDataEntered = computed(
         JSON.stringify(getEmptyBaseData()))
 );
 
-const basedataNameIsNotChanged = computed(() => currentBaseData.value?.name === selectedBaseData.value?.name);
+const basedataNameIsNotChanged = computed(
+  () => currentBaseData.value?.name === selectedBaseData.value?.name
+);
 const saveLeave = useSaveLeave(isDataEntered);
 
 const baseDataNames = computed(() =>


### PR DESCRIPTION
# Pull Request

## Changes

Fixed the "Anlegen" Button in the Base Data View, so you can only add a new template if the name of the base data set has been changed.

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

- ~[ ] Met all acceptance criteria of the issue~
- [x] Added meaningful PR title and list of changes in the description
- [x] Wrote code and comments in English
- ~[ ] Added tests~
- [x] Removed waste on branch (e.g. `console.log`)
- [x] Considered and tested accessibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The "Anlegen" (Create) button is now disabled if the base data name has not been changed, preventing duplicate creation with the same name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->