### PR TITLE
adjust encoder for URL sharing

### DIFF
--- a/sitzverteilung-frontend/src/utility/urlEncoder.ts
+++ b/sitzverteilung-frontend/src/utility/urlEncoder.ts
@@ -23,9 +23,9 @@ export async function writeToUrlParam<T>(
     .replace(/\//g, "_")
     .replace(/=+$/, "");
   const totalLength = result.length + url.length;
-  if (totalLength > 2048) {
+  if (totalLength > 8192) {
     throw new Error(
-      `The amount of data to be url encoded is too high. Maximum is 2048, but was ${totalLength}`
+      `The amount of data to be url encoded is too high. Maximum is 8192, but was ${totalLength}`
     );
   }
   return result;

--- a/sitzverteilung-frontend/src/utility/validation.ts
+++ b/sitzverteilung-frontend/src/utility/validation.ts
@@ -11,7 +11,7 @@ export const FieldValidationRules = {
 
 export const LimitConfiguration = {
   limitName: 45,
-  limitGroups: 18,
+  limitGroups: 30,
   limitVotes: 99_999_999,
   limitCommitteeSize: 999,
 } as const;

--- a/sitzverteilung-frontend/tests/utility/urlEncoder.spec.ts
+++ b/sitzverteilung-frontend/tests/utility/urlEncoder.spec.ts
@@ -28,7 +28,8 @@ describe("urlEncoder tests", () => {
     expect(JSON.stringify(object)).toEqual(JSON.stringify(baseData));
   });
 
-  test("conforms to maximum url length of 2048", async () => {
+  //Test export limit with maximum URL length of 8192 (smartphone browsers)
+  test("conforms to maximum url length of 8192", async () => {
     // given
     const baseData = getTestBaseDataInputLimit();
 
@@ -37,7 +38,7 @@ describe("urlEncoder tests", () => {
     const length = `${url}${urlParam}`.length;
 
     // then
-    expect(length).toBeLessThanOrEqual(2048);
+    expect(length).toBeLessThanOrEqual(8192);
   });
 
   test("throws error when input to large", async () => {


### PR DESCRIPTION
# Pull Request

## Changes
Adjusted size of encoder to fit mozilla, chrome and phone browser and adjusted max group size to 30.

## Reference

Issue: #SITZVERT-64

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [x] Wrote code and comments in English
- [x] Added tests
- [x] Removed waste on branch (e.g. `console.log`)
- [x] Considered and tested accessibility
